### PR TITLE
Changed default from Python 2 to Python 3 as support for the former i…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
  
 # Sets the Python executable.
 # It will be the executable for the interpreter set up for the command line.
-PYTHON   = python
+PYTHON   = python3
  
 # Sets the distribution folder.
 # It will be the 'dist' folder.

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Additionally, the project is offered as a `Pypi package`_, and can be installed 
 Making use of the parser
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once the project is installed it can be used in a similar way to this (using Python 2.7)::
+Once the project is installed it can be used in a similar way to this (using Python 3.6)::
 
     import codecs
     import os
@@ -90,9 +90,9 @@ Once the project is installed it can be used in a similar way to this (using Pyt
 
     if __name__ == '__main__':
         print('File to JSON test')
-        path = raw_input(
+        path = input(
             'Please enter the full path to a CWR file (e.g. c:/documents/file.cwr): ')
-        output = raw_input(
+        output = input(
             'Please enter the full path to the file where the results will be stored: ')
         print('\n')
         print('Reading file %s' % path)

--- a/make.bat
+++ b/make.bat
@@ -12,7 +12,7 @@ REM Sets the variables
 REM Sets the Python executable.
 REM It will be the executable for the interpreter set up for the command line.
 if "%PYTHON%" == "" (
-	set PYTHON=python
+	set PYTHON=python3
 )
 
 REM Sets the distribution folder.


### PR DESCRIPTION
…s already removed.

Can someone also please update the release on PyPI for `pip`, as that release is still on version 0.0.40 and the latest version here is 0.0.8? Is this an issue for lack of administrative access, or lack of a maintainer/packager to review the changes?