### PR TITLE
Fix CIS Character Set docs links to SR06-1311 files

### DIFF
--- a/docs/source/cwr_standard/documents.rst
+++ b/docs/source/cwr_standard/documents.rst
@@ -13,34 +13,45 @@ Specification
 
 A single file contains the standard specification:
 
-- :download:`Functional specifications: Common Works Registration version 2.1. - Rev.7 (CWR11-1991R1) <../_downloads/cwr_files/specification.rar>`
+- :download:`Functional specifications: Common Works Registration version 2.2 Rev 2 (CWR19-1070R1) <../_downloads/CWR19-1070R1_Functional_specifications_CWR_version_2-2_Rev2_2022-02-03_EN.txt>`
+- :download:`Functional specifications PDF (CWR19-1070R1) <../_downloads/CWR19-1070R1_Functional_specifications_CWR_version_2-2_Rev2_2022-02-03_EN.pdf>`
+- :download:`Functional specifications: Common Works Registration version 2.1 Rev 8 (CWR11-1991R4) <../_downloads/CWR11-1991R4_Functional_specifications_CWR_version_2-1_Rev8_2019-10-18_EN.pdf>`
 
 Additional information about rules to be used when writing into a file can be found on the following files:
 
-- :download:`CIS Character Set Rules (CWR11-1494) <../_downloads/cwr_files/charset_rules.rar>`
-- :download:`Amendments of TIS data (TIS09-1546R1) <../_downloads/cwr_files/tis_amend.rar>`
+- :download:`CIS Character Set Rules (SR06-1311) <../_downloads/SR06-1311_Standards-And_Rules_Working_Group_CIS_Character_Set_EN.doc>`
+- :download:`CIS Character Set Appendix A spreadsheet (SR06-1311aR10) <../_downloads/SR06-1311aR10_Specifications_CIS_Character_Set_2010-10-05_EN.xls>`
+- :download:`Amendments of TIS data (TIS09-1546R1) <../_downloads/TIS09-1546R1_Territory_Information_System_2012-01-20_EN.pdf>`
+
+Note: older Sphinx pages linked ``cwr_files/charset_rules.rar`` and labelled it
+``CWR11-1494``. That archive is not present in this tree. ``CWR11-1494`` is the
+CWR user manual document ID; the CIS Character Set rules are ``SR06-1311``
+(referenced from the Functional Specs §2.1 as the CIS character set).
 
 Manuals
 -------
 
 There is a user manual to help when working with these files:
 
-- :download:`CWR v2.1 User Manual (CWR11-1494) <../_downloads/cwr_files/user_manual.rar>`
+- :download:`CWR User Manual (CWR19-0479) <../_downloads/CWR19-0479_Common_Works_Registration_User_Manual_2019-04-04_EN.pdf>`
+- :download:`CWR User Manual text extract (CWR19-0479) <../_downloads/CWR19-0479_Common_Works_Registration_User_Manual_2019-04-04_EN.txt>`
+- :download:`Archived CWR v2.1 User Manual (CWR11-1494) <../_downloads/archive/CWR11-1494_CWR_User_Manual_2011-09-23_E_2011-09-23_EN.pdf>`
 
 Data Files
 ----------
 
 Some files contain information required to fill and validate the CWR files.
 
-- :download:`CWR Validation and Lookup Tables (CRF020) <../_downloads/cwr_files/tables.rar>`
-- :download:`CWR Sender ID and Codes (CWR06-1972) <../_downloads/cwr_files/sender_id_code.rar>`
-- :download:`CWR Error Messages (CWR08-2493) <../_downloads/cwr_files/errors.rar>`
+- :download:`CWR Validation and Lookup Tables (IS-CRFCRF-0020R7) <../_downloads/IS-CRFCRF-0020R7__CWR_validation_and_lookup_tables_2005_07_28_EN.doc>`
+- :download:`CWR 2.x Lookup Table (CWR08-3615R1) <../_downloads/CWR08-3615R1_CWR_2x_Lookup_Table_2021-09-16_EN.xlsx>`
+- :download:`CWR Sender ID and Codes (CWR06-1972) <../_downloads/CWR06-1972_CWR_sender_ID_and_codes_(May_2026)_2026-05-22_EN.xlsx>`
+- :download:`CWR Error Messages (CWR08-2493) <../_downloads/CWR08-2493_Specifications_CWR_Error_messages_2014-01-16_EN.pdf>`
 - EDI Standards (IM0047) (MISSING)
 
 TIS information.
 
-- :download:`TIS Territories (TIS09-1540a) <../_downloads/cwr_files/tis_territories.rar>`
-- :download:`TIS Hierarchies (TIS09-1540c) <../_downloads/cwr_files/tis_hierarchies.rar>`
+- :download:`TIS Territories (TIS09-1540a) <../_downloads/TIS09-1540a_Territories_2009-08-27_EN.xls>`
+- :download:`TIS Hierarchies (TIS09-1540c) <../_downloads/TIS09-1540c_Hierarchies_2009-08-27_EN.xls>`
 
 Other Files
 -----------
@@ -50,14 +61,14 @@ others have a very specific use.
 
 The CWR light is a variant which reduces greatly the number of fields in the records.
 
-- :download:`CWR Light Specifications (CWR08-3540) <../_downloads/cwr_files/cwr_light.rar>`
+- :download:`CWR Light Specifications (CWR08-3540) <../_downloads/CWR08-3540_Specifications_CWR_Light_2008-11-13_EN.pdf>`
 
 The following files are used to prepare a CWR-based communication between two parties.
 
-- :download:`CWR Publisher Questionnaire (CWR07-1411) <../_downloads/cwr_files/questionnary_publisher.rar>`
-- :download:`CWR Society Questionnaire (CWR08-1983) <../_downloads/cwr_files/questionnary_society.rar>`
+- :download:`CWR Society Questionnaire (CWR07-1411) <../_downloads/CWR07-1411_CWR_Society_Questionnaire_2010-10-01_EN.xls>`
+- :download:`CWR Publisher Questionnaire (CWR08-1983) <../_downloads/CWR08-1983_Survey_CWR_Publisher_Questionnaire_2010-10-06_EN.xls>`
 
 There is an implementation spreadsheet showing society and publisher communications have been established with the CWR
 standard.
 
-- :download:`CWR Implementation Spreadsheet (CWR06-1950) <../_downloads/cwr_files/impl_sheet.rar>`
+- :download:`CWR Implementation Spreadsheet (CWR06-1950) <../_downloads/CWR06-1950_CWR_Implementation_spreadsheet_2016-07-01_EN.pdf>`


### PR DESCRIPTION
## Summary

Sphinx `documents.rst` linked a missing `cwr_files/charset_rules.rar` and mislabelled it **CWR11-1494** (that ID is the CWR user manual).

This PR retargets downloads to the mirrored CIS Character Set materials already under `docs/source/_downloads/`:

- **SR06-1311** — `SR06-1311_Standards-And_Rules_Working_Group_CIS_Character_Set_EN.doc`
- **SR06-1311aR10** — `SR06-1311aR10_Specifications_CIS_Character_Set_2010-10-05_EN.xls`

Also retargets other Sphinx download links from missing `.rar` archives to the unpacked files present in `_downloads/` (specs, manuals, lookup tables, TIS, questionnaires, etc.).

## Context

CWR Functional Specs §2.1 cite **SR06-1311** as the CIS character set.

## Test plan

- [ ] Confirm Sphinx `:download:` paths resolve for the Character Set `.doc` / `.xls`
- [ ] Spot-check a few other retargeted download links under `_downloads/`